### PR TITLE
Additional methods required for rake tasks

### DIFF
--- a/lib/fcrepo_wrapper/instance.rb
+++ b/lib/fcrepo_wrapper/instance.rb
@@ -199,7 +199,7 @@ module FcrepoWrapper
     end
 
     def download
-      unless File.exists?(config.download_path) && validate?(config.download_path)
+      unless File.exists?(config.download_path) && md5.validate?(config.download_path)
         Downloader.fetch_with_progressbar config.download_url, config.download_path
         md5.validate! config.download_path
       end

--- a/lib/fcrepo_wrapper/instance.rb
+++ b/lib/fcrepo_wrapper/instance.rb
@@ -141,6 +141,14 @@ module FcrepoWrapper
       config.version
     end
 
+    def instance_dir
+      config.instance_dir
+    end
+
+    def options
+      config.options
+    end
+
     ##
     # Clean up any files fcrepo_wrapper may have downloaded
     def clean!

--- a/spec/lib/fcrepo_wrapper/instance_spec.rb
+++ b/spec/lib/fcrepo_wrapper/instance_spec.rb
@@ -27,5 +27,14 @@ describe FcrepoWrapper::Instance do
     subject { wrapper.md5 }
     it { is_expected.to be_instance_of FcrepoWrapper::MD5 }
   end
-end
 
+  describe "#instance_dir" do
+    subject { File.exists?(wrapper.instance_dir) }
+    it { is_expected.to be true }
+  end
+
+  describe "#options" do
+    subject { wrapper.options }
+    it { is_expected.to eq({}) }
+  end 
+end


### PR DESCRIPTION
The rake tasks included in the gem called the methods `instance_dir` and `options` on FcrepoInstance, but they were undefined.

Alternatively, we could delegate these methods, along with others such as `port`, etc. to `config`, if you'd prefer. Otherwise, this PR should get the rake tasks to work as written.
