### PR TITLE
Refactor instance defaults

### DIFF
--- a/exe/fcrepo_wrapper
+++ b/exe/fcrepo_wrapper
@@ -24,7 +24,7 @@ args = OptionParser.new do |opts|
     options[:version] = v
   end
 
-  opts.on("-pPORT", "--port PORT", "Specify the port fcrepo should run at (default: 8080)") do |p|
+  opts.on("-pPORT", "--port PORT", "Specify the port fcrepo should run at (default: #{FcrepoWrapper.default_fcrepo_port})") do |p|
     if p == 'random'
       options[:port] = nil
     else

--- a/lib/fcrepo_wrapper.rb
+++ b/lib/fcrepo_wrapper.rb
@@ -10,19 +10,12 @@ module FcrepoWrapper
     '4.5.0'
   end
 
-  def self.default_instance_options
-    @default_instance_options ||= {
-      port: '8080',
-      version: FcrepoWrapper.default_fcrepo_version
-    }
-  end
-
-  def self.default_instance_options=(options)
-    @default_instance_options = options
+  def self.default_fcrepo_port
+    '8080'
   end
 
   def self.default_instance(options = {})
-    @default_instance ||= FcrepoWrapper::Instance.new default_instance_options.merge(options)
+    @default_instance ||= FcrepoWrapper::Instance.new options
   end
 
   ##

--- a/lib/fcrepo_wrapper/configuration.rb
+++ b/lib/fcrepo_wrapper/configuration.rb
@@ -95,7 +95,7 @@ module FcrepoWrapper
       # Check if the port option has been explicitly set to nil.
       # this means to start fcrepo_wrapper on a random open port
       return nil if options.key?(:port) && !options[:port]
-      options[:port] || FcrepoWrapper.default_instance_options[:port]
+      options[:port] || FcrepoWrapper.default_fcrepo_port
     end
 
     def validate
@@ -132,8 +132,16 @@ module FcrepoWrapper
         ['.fcrepo_wrapper', '~/.fcrepo_wrapper']
       end
 
+      def default_download_dir
+        if defined? Rails
+          File.join(Rails.root, 'tmp')
+        else
+          Dir.tmpdir
+        end
+      end
+
       def download_dir
-        @download_dir ||= options.fetch(:download_dir, Dir.tmpdir)
+        @download_dir ||= options.fetch(:download_dir, default_download_dir)
         FileUtils.mkdir_p @download_dir
         @download_dir
       end

--- a/lib/fcrepo_wrapper/tasks/fcrepo_wrapper.rake
+++ b/lib/fcrepo_wrapper/tasks/fcrepo_wrapper.rake
@@ -4,7 +4,6 @@ require 'fcrepo_wrapper'
 namespace :fcrepo do
   desc "Load the fcrepo options and fcrepo instance"
   task :environment do
-    FcrepoWrapper.default_instance_options[:download_dir] ||= Rails.root.to_s + '/tmp' if defined? Rails
     @fcrepo_instance = FcrepoWrapper.default_instance
   end
 


### PR DESCRIPTION
- Removes default_instance_options
- Uses rails_root/tmp rather than system temp dir when running in Rails contexts (rake, etc.)
