### PR TITLE
Don't cast config file booleans to strings

### DIFF
--- a/lib/fcrepo_wrapper/configuration.rb
+++ b/lib/fcrepo_wrapper/configuration.rb
@@ -125,7 +125,7 @@ module FcrepoWrapper
           $stderr.puts "Unable to parse config #{config_file}" if verbose
           return {}
         end
-        config.each_with_object({}) { |(k, v), h| h[k.to_sym] = v.to_s }
+        config.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
       end
 
       def default_configuration_paths

--- a/spec/fixtures/sample_config.yml
+++ b/spec/fixtures/sample_config.yml
@@ -1,1 +1,5 @@
 port: 9999
+version_file: path/to/VERSION
+enable_jms: no
+verbose: false
+validate: yes

--- a/spec/lib/fcrepo_wrapper/configuration_spec.rb
+++ b/spec/lib/fcrepo_wrapper/configuration_spec.rb
@@ -27,9 +27,20 @@ describe FcrepoWrapper::Configuration do
       allow(config).to receive(:default_configuration_paths).and_return([])
     end
     let(:options) { { config: 'spec/fixtures/sample_config.yml' } }
+
     it "uses values from the config file" do
-      expect(config.port).to eq '9999'
+      expect(config.version_file).to eq 'path/to/VERSION'
     end
+    it "evalates yaml true values as ruby booleans" do
+      expect(config.validate).to be true
+    end
+    it "evaluates yaml false values as ruby booleans" do
+      expect(config.verbose?).to be false
+    end
+    it "doesn't cast numerics to strings" do
+      expect(config.port).to eq 9999
+    end
+
   end
 
   describe "#validate" do

--- a/spec/lib/fcrepo_wrapper/md5_spec.rb
+++ b/spec/lib/fcrepo_wrapper/md5_spec.rb
@@ -15,7 +15,7 @@ describe FcrepoWrapper::MD5 do
     end
 
     context "with a correct checksum" do
-      let(:options) { { md5sum: 'de0b8ccf94db635e149b4c01027b34c1' } }
+      let(:options) { { md5sum: '75e5b2fea7e7b756fa4ad4ca58e96b8c' } }
       it "doesn't raise an error" do
         expect { subject }.not_to raise_error
       end


### PR DESCRIPTION
**SHORT VERSION**
The current code casts all config file values to strings.  This is a problem for booleans because boolean values from the config file that are cast to strings will never evaluate as false.  I copied the pattern in solr_wrapper, which does not cast the yaml file values to strings.  

**LONG VERSION**
I need to be able to turn off the jms listener from a config file and was unable to figure out how to do it. Turns out that it's not possible because of a side effect of casting booleans to strings:

```
"false" ? true : false
 => true 
"true" ? true : false
 => true 
```

As a result, there's no way to disable the jms listener within a config file - i.e.:

```
enable_jms: false
```

gets cast to

```
{enable_jms: "false"}
```

which means

```
jms_enabled?
=> "false"
```

which evaluates as boolean true so that

```
("-Dfcrepo.spring.jms.configuration=#{spring_noop_file}" unless jms_enabled?)
```

can never get included in the instance's process_arguments via a config file setting.  But you can do it in successfully from the command line because `enable_jms` doesn't get cast to a string when set via command line arguments.
