### PR TITLE
Allow wrapper configuration file to be read from rails config dir

### DIFF
--- a/lib/fcrepo_wrapper/configuration.rb
+++ b/lib/fcrepo_wrapper/configuration.rb
@@ -135,7 +135,7 @@ module FcrepoWrapper
       end
 
       def default_configuration_paths
-        ['.fcrepo_wrapper', '~/.fcrepo_wrapper']
+        ['./config/fcrepo_wrapper.yml', '.fcrepo_wrapper', '~/.fcrepo_wrapper']
       end
 
       def default_download_dir


### PR DESCRIPTION
@cbeer would you be open to a change like this to let the wrapper config be read from a .yml config file in the rails application's config directory if such a config file exists?

Order of precedence (highest to lowest):
- command line parameters
- `./config/fcrepo_wrapper.yml`  (assumes you're launching from your application root, ignored)
- `.fcrepo_wrapper` (hidden file in the root of whatever project you're working on)
- `~/.fcrepo_wrapper` (hidden file in the logged-in user's home directory)
