### PR TITLE
Check if Rails.root is nil

### DIFF
--- a/lib/fcrepo_wrapper/configuration.rb
+++ b/lib/fcrepo_wrapper/configuration.rb
@@ -139,7 +139,7 @@ module FcrepoWrapper
       end
 
       def default_download_dir
-        if defined? Rails
+        if defined?(Rails) && Rails.root
           File.join(Rails.root, 'tmp')
         else
           Dir.tmpdir

--- a/spec/lib/fcrepo_wrapper/configuration_spec.rb
+++ b/spec/lib/fcrepo_wrapper/configuration_spec.rb
@@ -60,4 +60,14 @@ describe FcrepoWrapper::Configuration do
     subject { config.ignore_md5sum }
     it { is_expected.to be false }
   end
+
+  describe "#default_download_path" do
+    let(:rails)   { double("Raylz", root: nil) }
+    let(:options) { {} }
+    context "when Rails.root is nil" do
+      before { stub_const("FcrepoWrapper::Configuration::Rails", rails) }
+      subject { config.default_download_path }
+      it { is_expected.to start_with(Dir.tmpdir) }
+    end
+  end
 end


### PR DESCRIPTION
I'm seeing this error in Travis, and when I run the CI build locally if fcrepo hasn't been downloaded yet:

``` bash
TypeError: no implicit conversion of nil into String
/home/travis/build/projecthydra/sufia/vendor/bundle/ruby/2.2.0/gems/fcrepo_wrapper-0.5.1/lib/fcrepo_wrapper/configuration.rb:143:in `join'
```
