### PR TITLE
 Ensuring up to date system gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
 
 jdk:
 - oraclejdk8
+
+before_install:
+  - gem update --system


### PR DESCRIPTION
 This fixes the following error:

 ```console
 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

 can't modify frozen String
 ```

Related to sickill/rainbow#48

Referencing Blacklight's workaround

https://github.com/projectblacklight/blacklight/blob/master/.travis.yml#L21