### PR TITLE
Remove unused simple_solr_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Wrap any task with a Fcrepo instance:
 
 ```ruby
-FcrepoWrapper.wrap do |solr|
+FcrepoWrapper.wrap do |fedora_repo|
   # Something that requires Fcrepo
 end
 ```

--- a/fcrepo_wrapper.gemspec
+++ b/fcrepo_wrapper.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "simple_solr_client"
   spec.add_development_dependency "coveralls"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'fcrepo_wrapper'
-require 'simple_solr_client'
 
 require 'rspec'
 


### PR DESCRIPTION
A couple vestiges of its roots -- `simple_solr_client` and
a line in the README. Completely cosmetic.